### PR TITLE
store to mongodb & fix validation

### DIFF
--- a/listener/src/api/utils.go
+++ b/listener/src/api/utils.go
@@ -1,12 +1,7 @@
 package api
 
-// A valid signature is a 0x prefixed hex string of 192 characters (without the prefix)
-// A valid payload is a 0x prefixed hex string.
-func validateSignature(payload string, signature string) bool {
-	// validate the payload
-	if len(payload) < 2 || payload[:2] != "0x" {
-		return false
-	}
+// A valid signature is a 0x prefixed hex string of 194 characters (including the prefix)
+func validateSignature(signature string) bool {
 
 	// validate the signature
 	if len(signature) != 194 || signature[:2] != "0x" {


### PR DESCRIPTION
This commit adds the decoding of the payload of a valid request to the `/signature` endpoint and stores it decoded in the mongodb.