### PR TITLE
Add signaturesAggr & signatures

### DIFF
--- a/listener/src/api/api.go
+++ b/listener/src/api/api.go
@@ -66,7 +66,9 @@ func (s *httpApi) SetupRouter() *mux.Router {
 
 	// Endpoints
 	r.HandleFunc("/", s.handleRoot).Methods(http.MethodGet)
-	r.HandleFunc("/signature", s.handleSignature).Methods(http.MethodPost)
+	r.HandleFunc("/newSignature", s.handleSignature).Methods(http.MethodPost)
+	r.HandleFunc("/signaturesByValidator", s.handleGetSignatures).Methods(http.MethodPost)
+	r.HandleFunc("/signaturesByValidatorAggr", s.handleGetSignaturesAggr).Methods(http.MethodPost)
 
 	// Middlewares
 	// r.Use(corsmiddleware()))

--- a/listener/src/api/handlers.go
+++ b/listener/src/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dappnode/validator-monitoring/listener/src/logger"
 	"github.com/dappnode/validator-monitoring/listener/src/types"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 func (s *httpApi) handleRoot(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +82,108 @@ func (s *httpApi) handleSignature(w http.ResponseWriter, r *http.Request) {
 	logger.Info("A new message with pubkey " + decodedPayload.Pubkey + " was decoded and inserted into MongoDB successfully")
 	s.respondOK(w, "Message validated and inserted into MongoDB")
 
+}
+
+func (s *httpApi) handleGetSignatures(w http.ResponseWriter, r *http.Request) {
+	var req types.SignaturesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	filter := bson.M{"pubkey": req.Pubkey, "network": req.Network}
+	cursor, err := s.dbCollection.Find(r.Context(), filter)
+	if err != nil {
+		s.respondError(w, http.StatusInternalServerError, "Error fetching signatures from MongoDB")
+		return
+	}
+	defer cursor.Close(r.Context())
+
+	var signatures []bson.M
+	if err = cursor.All(r.Context(), &signatures); err != nil {
+		s.respondError(w, http.StatusInternalServerError, "Error reading signatures from cursor")
+		return
+	}
+
+	s.respondOK(w, signatures)
+}
+
+// Endpoint that returns an aggregation of all signatures for a given pubkey and network in this format:
+// [
+//
+//	{
+//	    "label": "example_label",
+//	    "network": "stader",
+//	    "pubkey": "0xb48c495c19082d892f38227bced89f7199f4e9b642bf94c7f2f1ccf29c0e6a6f54d653002513aa7cdb56c88368797ec",
+//	    "signatures": [
+//	        {
+//	            "platform": "dappnode",
+//	            "signature": "0xa8b00e7746a523346c5165dfa80ffafe52317c6fe6cdcfabd41886f9c8209b829266c5000597142b58dddbcc9c23cfd81315180acf18bb000db50d08293bc539e06a7c751d3d9dec89fb441b3ba6aefdeeff9cfed72fb41171173f22e2993e74",
+//	            "timestamp": "185921877"
+//	        },
+//	        {
+//	            "platform": "dappnode",
+//	            "signature": "0xa8b00e7746a523346c5165dfa80ffafe52317c6fe6cdcfabd41886f9c8209b829266c5000597142b58dddbcc9c23cfd81315180acf18bb000db50d08293bc539e06a7c751d3d9dec89fb441b3ba6aefdeeff9cfed72fb41171173f22e2993e74",
+//	            "timestamp": "185921877"
+//	        }
+//	    ]
+//	}
+//
+// ]
+func (s *httpApi) handleGetSignaturesAggr(w http.ResponseWriter, r *http.Request) {
+	var req types.SignaturesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.respondError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	// Define the aggregation pipeline
+	// We should probably add pubkey to each signatures array element, so a 3rd party can easily verify the signature?
+	pipeline := []bson.M{
+		{
+			"$match": bson.M{
+				"pubkey":  req.Pubkey,
+				"network": req.Network,
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id": bson.M{"pubkey": "$pubkey", "network": "$network", "label": "$label"},
+				"signatures": bson.M{
+					"$push": bson.M{
+						"signature": "$signature",
+						"timestamp": "$timestamp",
+						"platform":  "$platform",
+					},
+				},
+			},
+		},
+		{
+			"$project": bson.M{
+				"_id":        0,
+				"pubkey":     "$_id.pubkey",
+				"network":    "$_id.network",
+				"label":      "$_id.label",
+				"signatures": 1,
+			},
+		},
+	}
+
+	cursor, err := s.dbCollection.Aggregate(r.Context(), pipeline, options.Aggregate())
+	if err != nil {
+		s.respondError(w, http.StatusInternalServerError, "Error aggregating signatures from MongoDB")
+		return
+	}
+	defer cursor.Close(r.Context())
+
+	var results []bson.M
+	if err := cursor.All(r.Context(), &results); err != nil {
+		s.respondError(w, http.StatusInternalServerError, "Error reading aggregation results")
+		return
+	}
+
+	// Respond with the aggregation results
+	s.respondOK(w, results)
 }
 
 // TODO: error handling

--- a/listener/src/types/types.go
+++ b/listener/src/types/types.go
@@ -17,3 +17,8 @@ type HttpErrorResp struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
+
+type SignaturesRequest struct {
+	Pubkey  string `json:"pubkey"`
+	Network string `json:"network"`
+}


### PR DESCRIPTION
In a mongodb with 3 signatures (where 2 of them have the same pubkey & network):
![Screenshot_20240328_165611](https://github.com/dappnode/validator-monitoring/assets/36164126/43c5dbc1-2a1b-4db2-8cbf-dd2467569210)

endpoint `/signaturesAggr` returns all signatures of the same validator (defined by pubkey and network) in an array:

request: POST to mongodb with json body:
```
{
    "pubkey": "0xb48c495c19082d892f38227bced89f7199f4e9b642bf94c7f2f1ccf29c0e6a6f54d653002513aa7cdb56c88368797ec",
    "network": "stader"
}
```


reponse:
```
[
    {
        "label": "example_label",
        "network": "stader",
        "pubkey": "0xb48c495c19082d892f38227bced89f7199f4e9b642bf94c7f2f1ccf29c0e6a6f54d653002513aa7cdb56c88368797ec",
        "signatures": [
            {
                "platform": "dappnode",
                "signature": "0xa8b00e7746a523346c5165dfa80ffafe52317c6fe6cdcfabd41886f9c8209b829266c5000597142b58dddbcc9c23cfd81315180acf18bb000db50d08293bc539e06a7c751d3d9dec89fb441b3ba6aefdeeff9cfed72fb41171173f22e2993e74",
                "timestamp": "185921877"
            },
            {
                "platform": "dappnode",
                "signature": "0xa8b00e7746a523346c5165dfa80ffafe52317c6fe6cdcfabd41886f9c8209b829266c5000597142b58dddbcc9c23cfd81315180acf18bb000db50d08293bc539e06a7c751d3d9dec89fb441b3ba6aefdeeff9cfed72fb41171173f22e2993e74",
                "timestamp": "185921877"
            }
        ]
    }
]
```