### PR TITLE
Init bls only once before serving api

### DIFF
--- a/listener/cmd/listener/main.go
+++ b/listener/cmd/listener/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dappnode/validator-monitoring/listener/internal/api"
 	"github.com/dappnode/validator-monitoring/listener/internal/config"
 	"github.com/dappnode/validator-monitoring/listener/internal/logger"
+	"github.com/herumi/bls-eth-go-binary/bls"
 )
 
 func main() {
@@ -14,6 +15,15 @@ func main() {
 		logger.Fatal("Failed to load config: " + err.Error())
 	}
 	logger.SetLogLevelFromString(config.LogLevel)
+
+	// This is a configuration of the BLS library at the process level. Notice how bls.Init() does not return an initialized BLS object.
+	// Any call to bls functions within the process will use this configuration. We initialize bls before starting the api.
+	if err := bls.Init(bls.BLS12_381); err != nil {
+		logger.Fatal("Failed to initialize BLS: " + err.Error())
+	}
+	if err := bls.SetETHmode(bls.EthModeDraft07); err != nil {
+		logger.Fatal("Failed to set BLS ETH mode: " + err.Error())
+	}
 
 	s := api.NewApi(
 		config.Port,

--- a/listener/internal/api/api.go
+++ b/listener/internal/api/api.go
@@ -6,7 +6,6 @@ import (
 	"github.com/dappnode/validator-monitoring/listener/internal/api/routes"
 	"github.com/dappnode/validator-monitoring/listener/internal/logger"
 	"github.com/dappnode/validator-monitoring/listener/internal/mongodb"
-	"github.com/herumi/bls-eth-go-binary/bls"
 )
 
 type httpApi struct {
@@ -47,15 +46,6 @@ func (s *httpApi) Start() {
 	dbCollection := dbClient.Database("validatorMonitoring").Collection("signatures")
 	if dbCollection == nil {
 		logger.Fatal("Failed to connect to MongoDB collection")
-	}
-
-	// This is a configuration of the BLS library at the process level. Notice how bls.Init() does not return an initialized BLS object.
-	// Any call to bls functions within the process will use this configuration. We initialize bls before starting the api.
-	if err := bls.Init(bls.BLS12_381); err != nil {
-		logger.Fatal("Failed to initialize BLS: " + err.Error())
-	}
-	if err := bls.SetETHmode(bls.EthModeDraft07); err != nil {
-		logger.Fatal("Failed to set BLS ETH mode: " + err.Error())
 	}
 
 	// setup the http api


### PR DESCRIPTION
bls initialization is managed at process level, no need to save an initialized bls instance and pass it as parameters when needed